### PR TITLE
Change binary paths to allow jenkins user to execute applications

### DIFF
--- a/tasks/helm.yml
+++ b/tasks/helm.yml
@@ -18,7 +18,7 @@
 - name: Create link to helm binary
   file:
     src: /var/lib/helm/helm
-    dest: /usr/local/bin/helm
+    dest: /usr/bin/helm
     state: link
     force: True
 

--- a/tasks/kops.yml
+++ b/tasks/kops.yml
@@ -15,7 +15,7 @@
 - name: Create link to kops binary
   file:
     src: /var/lib/kops/kops
-    dest: /usr/local/bin/kops
+    dest: /usr/bin/kops
     state: link
     force: True
 

--- a/tasks/kubectl.yml
+++ b/tasks/kubectl.yml
@@ -15,6 +15,6 @@
 - name: Create link to kubectl binary
   file:
     src: /var/lib/kubectl/kubectl
-    dest: /usr/local/bin/kubectl
+    dest: /usr/bin/kubectl
     state: link
     force: True


### PR DESCRIPTION
Reason: binary is not being read at playbook/jenkins level. definitely something to do with `Jenkins` being a service account. 

No time to investigate why this is happening - SHIP SHIP SHIP instead!