### PR TITLE
Add programmatic AWS credential management script

### DIFF
--- a/tasks/groovy_scripts.yml
+++ b/tasks/groovy_scripts.yml
@@ -10,5 +10,6 @@
   with_items:
     - github_oauth.groovy
     - credentials.groovy
+    - aws_credentials.groovy
 
 

--- a/templates/aws_credentials.groovy.j2
+++ b/templates/aws_credentials.groovy.j2
@@ -1,0 +1,29 @@
+#!groovy
+
+import jenkins.model.*
+import com.cloudbees.plugins.credentials.*
+import com.cloudbees.plugins.credentials.common.*
+import com.cloudbees.plugins.credentials.domains.*
+import com.cloudbees.plugins.credentials.impl.*
+import com.cloudbees.jenkins.plugins.sshcredentials.impl.*
+import hudson.plugins.sshslaves.*;
+
+domain = com.cloudbees.plugins.credentials.domains.Domain.global()
+store = Jenkins.instance.getExtensionList('com.cloudbees.plugins.credentials.SystemCredentialsProvider')[0].getStore()
+
+
+def addAwsCredentials(id, accessKey, secretKey, description) {
+    c = new com.cloudbees.jenkins.plugins.awscredentials.AWSCredentialsImpl(
+        com.cloudbees.plugins.credentials.CredentialsScope.GLOBAL,
+        id,
+        accessKey,
+        secretKey,
+        description,
+        '',
+        ''
+    )
+}
+
+{% for secret in cc_jenkins_custom_aws_credentials.iteritems() %}
+store.addCredentials(domain, addAwsCredentials('{{ secret[1]['id'] }}', '{{ secret[1]['accessKey'] }}', '{{ secret[1]['secretKey'] }}', '{{ secret[1]['description'] }}'))
+{% endfor %}

--- a/templates/credentials.groovy.j2
+++ b/templates/credentials.groovy.j2
@@ -24,5 +24,5 @@ def addPassCredentials(name, id, username, password) {
 }
 
 {% for secret in cc_jenkins_credentials.iteritems() %}
-store.addCredentials(domain, addPassCredentials('{{ secret[1]['name'] }}', '{{ secret[1]['id'] }}', '{{ secret[1]['username'] }}', '{{ secret[1]['secret'] }}'))
+store.addCredentials(domain, addPassCredentials('{{ secret[1]['id'] }}', '{{ secret[1]['description'] }}', '{{ secret[1]['username'] }}', '{{ secret[1]['secret'] }}'))
 {% endfor %}


### PR DESCRIPTION
**Features**
* AWS credential management script allowing to define AWS keys in the following way:
```
cc_jenkins_custom_aws_credentials:
    s3-upload:
      id: s3-upload-permissions-prod
      accessKey: ABC123
      secretKey: zxyABC
      description: Permissions to upload objects to S3 buckets
```
**Fixes**
* Clarify naming convention for existing user/pass init script:

```
cc_jenkins_credentials:
    secret-user-pass:
        id: my-credentials
        username: username-here
        secret: v3rYs3cuR3P@ssw0rd
        description: Credentials to access xyz
```