### PR TITLE
Helm cleanup cron

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,3 +33,6 @@ cc_jenkins_plugins: []
 
 #GeerlingGuy roles' variables
 java_packages: java-1.8.0-openjdk
+
+helm_release_cap: 1 # days
+helm_release_log_file: helm_release_cleanup.log

--- a/tasks/helm_release_cleanup.yml
+++ b/tasks/helm_release_cleanup.yml
@@ -1,0 +1,22 @@
+---
+  - name: Ensure scripts directory exists
+    file:
+      path: "{{ jenkins_home }}/scripts"
+      state: directory
+      owner: jenkins
+      group: jenkins
+
+  - name: Generate Helm release cleanup script
+    template:
+      src: "helm_release_cleanup.py.j2"
+      dest: "{{ jenkins_home }}/scripts/helm_release_cleanup.py"
+      owner: jenkins
+      group: jenkins
+
+  - name: Configure Helm release cleanup cron
+    cron:
+      name: "Clean up Helm releases older than {{ helm_release_cap }} day(s)"
+      minute: "30"
+      hour: "12"
+      job: "python {{ jenkins_home }}/scripts/helm_release_cleanup.py"
+      user: jenkins

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -6,6 +6,8 @@
 
 - include: crons.yml
 
+- include: helm_release_cleanup.yml
+
 - include: docker-config.yml
 
 - include: aws_config.yml

--- a/templates/helm_release_cleanup.py.j2
+++ b/templates/helm_release_cleanup.py.j2
@@ -1,0 +1,56 @@
+#!/usr/bin/env python
+
+""" This script cleans up Helm deployments older than X days.
+
+To run this script, you must have:
+* Helm installed and initialised (helm init)
+* Permissions configured on Kubernetes cluster
+
+"""
+
+import logging
+import subprocess
+import datetime
+from dateutil.parser import parse
+
+DAYS_TO_KEEP="{{ helm_release_cap }}"
+LOG_FILE="{{ helm_release_log_file }}"
+
+def main():
+    logging.basicConfig(filename=LOG_FILE,level=logging.DEBUG,format='%(asctime)s %(message)s')
+
+    releases = subprocess.check_output("helm ls --namespace ephemeral -d | \
+                                          awk '{print $1\",\"$3,$4,$5,$6,$7}' | tail -n+2",
+                                          shell=True).split('\n')
+    releases.pop() # Remove last item which is an empty string
+    release_count = len(releases)
+
+    if release_count > 0:
+        logging.debug('Found %s releases older than %s day(s)' %(release_count, DAYS_TO_KEEP))
+
+    releases_deleted = []
+
+    for release in releases:
+        try:
+            release_name = release.split(",")[0]
+            release_updated = release.split(",")[1]
+
+            date = parse(release_updated)
+
+            if date < datetime.datetime.now() - datetime.timedelta(days=DAYS_TO_KEEP):
+                logging.debug('Deleting %s...' %release_name)
+                cmd = "helm delete --purge %s" %release_name
+                output = subprocess.check_call(cmd, shell=True)
+                if output != 0:
+                    logging.warning('Error deleting %s' %release_name)
+                else:
+                    logging.debug('Deleted %s' %release_name)
+                    releases_deleted += 1
+
+        except IndexError:
+            pass
+
+    logging.debug('Deleted %s releases' %len(releases_deleted))
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This PR adds a cron job running at midday cleaning up releases older than X days. 

```
-----> Destroying <jenkins-centos>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <jenkins-centos> destroyed.
       Finished destroying <jenkins-centos> (0m5.11s).
       Finished testing <jenkins-centos> (6m1.82s).
-----> Kitchen is finished. (6m2.17s)
```
