### PR TITLE
Add SSH credential management function

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -23,6 +23,8 @@ cc_jenkins_aws_credentials:
 
 cc_jenkins_custom_aws_credentials: {}
 
+cc_jenkins_ssh_credentials: {}
+
 cc_jenkins_k8s_clusters: {}
 
 cc_jenkins_host: http://localhost:8080

--- a/templates/credentials.groovy.j2
+++ b/templates/credentials.groovy.j2
@@ -23,6 +23,21 @@ def addPassCredentials(name, id, username, password) {
     )
 }
 
+def addSshPrivateKey(id, username, passphrase, description, key) {
+    privateKey = new BasicSSHUserPrivateKey(
+    CredentialsScope.GLOBAL,
+    id,
+    username,
+    new BasicSSHUserPrivateKey.DirectEntryPrivateKeySource(key),
+    passphrase,
+    description
+    )
+}
+
 {% for secret in cc_jenkins_credentials.iteritems() %}
 store.addCredentials(domain, addPassCredentials('{{ secret[1]['id'] }}', '{{ secret[1]['description'] }}', '{{ secret[1]['username'] }}', '{{ secret[1]['secret'] }}'))
+{% endfor %}
+
+{% for secret in cc_jenkins_ssh_credentials.iteritems() %}
+store.addCredentials(domain, addSshPrivateKey('{{ secret[1]['id'] }}', '{{ secret[1]['username'] }}', '{{ secret[1]['passphrase'] }}', '{{ secret[1]['description'] }}', '''{{ secret[1]['key'] }}'''))
 {% endfor %}

--- a/templates/helm_release_cleanup.py.j2
+++ b/templates/helm_release_cleanup.py.j2
@@ -13,7 +13,7 @@ import subprocess
 import datetime
 from dateutil.parser import parse
 
-DAYS_TO_KEEP="{{ helm_release_cap }}"
+DAYS_TO_KEEP={{ helm_release_cap }}
 LOG_FILE="{{ helm_release_log_file }}"
 
 def main():
@@ -28,7 +28,7 @@ def main():
     if release_count > 0:
         logging.debug('Found %s releases older than %s day(s)' %(release_count, DAYS_TO_KEEP))
 
-    releases_deleted = []
+    releases_deleted = 0
 
     for release in releases:
         try:
@@ -45,12 +45,12 @@ def main():
                     logging.warning('Error deleting %s' %release_name)
                 else:
                     logging.debug('Deleted %s' %release_name)
-                    releases_deleted += 1
+                    releases_deleted = releases_deleted + 1
 
         except IndexError:
             pass
 
-    logging.debug('Deleted %s releases' %len(releases_deleted))
+    logging.debug('Deleted %s releases' %releases_deleted)
 
 if __name__ == "__main__":
     main()


### PR DESCRIPTION
This PR adds the missing bit of functionality - SSH key management! 

## Configuration example:
```yaml
cc_jenkins_ssh_credentials:
    crowdcube-ec2-slaves-key:
      id: crowdcube-ec2-slaves-key
      username: jenkins
      passphrase: ""
      description: SSH key to connect from Jenkins Master to Slaves
      key: |
        -----BEGIN RSA PRIVATE KEY-----
        ...
        -----END RSA PRIVATE KEY-----
```

## Result
<img width="1091" alt="screen shot 2017-10-17 at 15 41 54" src="https://user-images.githubusercontent.com/15460047/31671370-bc184318-b351-11e7-9f7e-4ca07c86329f.png">
