### PR TITLE
Add conditional block for Helm crelease cleanup

### DIFF
--- a/tasks/crons.yml
+++ b/tasks/crons.yml
@@ -12,3 +12,10 @@
       minute: "30"
       hour: "0"
       job: "find {{ jenkins_home }}/workspace/* -exec rm -r \"{}\" \\;"
+
+  - name: Clean up dead Jenkins slaves
+    cron:
+      name: "Clean up dead Jenkins slaves"
+      minute: "0"
+      hour: "*"
+      job: "java -jar jenkins-cli.jar -auth {{ cc_jenkins_admin.user }}:{{ cc_jenkins_admin.token }} -s {{ cc_jenkins_host }} groovy {{ jenkins_home }}/scripts/offline_slave_cleanup.groovy"

--- a/tasks/groovy_scripts.yml
+++ b/tasks/groovy_scripts.yml
@@ -1,6 +1,5 @@
 ---
-
-- name: Generate groovy script templates
+- name: Generate groovy startup script templates
   template:
     src: "{{ item }}.j2"
     dest: "{{ jenkins_home }}/init.groovy.d/{{ item }}"
@@ -12,4 +11,18 @@
     - credentials.groovy
     - aws_credentials.groovy
 
+- name: Ensure scripts directory exists
+  file:
+    path: "{{ jenkins_home }}/scripts"
+    state: directory
+    owner: jenkins
+    group: jenkins
 
+- name: Generate groovy cron script templates
+  template:
+    src: "{{ item }}.j2"
+    dest: "{{ jenkins_home }}/scripts/{{ item }}"
+    owner: jenkins
+    group: jenkins
+  with_items:
+    - offline_slave_cleanup.groovy

--- a/tasks/helm_release_cleanup.yml
+++ b/tasks/helm_release_cleanup.yml
@@ -1,11 +1,4 @@
 ---
-  - name: Ensure scripts directory exists
-    file:
-      path: "{{ jenkins_home }}/scripts"
-      state: directory
-      owner: jenkins
-      group: jenkins
-
   - name: Generate Helm release cleanup script
     template:
       src: "helm_release_cleanup.py.j2"

--- a/templates/helm_release_cleanup.py.j2
+++ b/templates/helm_release_cleanup.py.j2
@@ -35,6 +35,10 @@ def main():
             release_name = release.split(",")[0]
             release_updated = release.split(",")[1]
 
+            # Ignore releases on Master branches
+            if release_name.startswith("web-master") or release_name.startswith("api-master"):
+                pass
+
             date = parse(release_updated)
 
             if date < datetime.datetime.now() - datetime.timedelta(days=DAYS_TO_KEEP):

--- a/templates/offline_slave_cleanup.groovy.j2
+++ b/templates/offline_slave_cleanup.groovy.j2
@@ -1,0 +1,10 @@
+#!groovy
+
+println "Cleaning up offline slaves..."
+hudson.model.Hudson.instance.slaves.each {
+    if(it.getComputer().isOffline()) {
+        println "Deleting ${it.name}"
+        it.getComputer().doDoDelete()
+    }
+}
+println "Done."


### PR DESCRIPTION
Current behaviour: all releases in ephemeral namespace get deleted after 24 hours. 

This PR adds web/api master deployment cleanup exclusion which allows PRs to retain connection to shared Redis, RabbitMQ. 