### PR TITLE
Fixes to Helm and slave cleanup scripts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -36,5 +36,5 @@ cc_jenkins_plugins: []
 #GeerlingGuy roles' variables
 java_packages: java-1.8.0-openjdk
 
-helm_release_cap: 1 # days
+helm_release_cap: 6 # hours
 helm_release_log_file: helm_release_cleanup.log

--- a/tasks/crons.yml
+++ b/tasks/crons.yml
@@ -18,4 +18,4 @@
       name: "Clean up dead Jenkins slaves"
       minute: "0"
       hour: "*"
-      job: "java -jar jenkins-cli.jar -auth {{ cc_jenkins_admin.user }}:{{ cc_jenkins_admin.token }} -s {{ cc_jenkins_host }} groovy {{ jenkins_home }}/scripts/offline_slave_cleanup.groovy"
+      job: "java -jar {{ jenkins_home }}/jenkins-cli.jar -auth {{ cc_jenkins_admin.user }}:{{ cc_jenkins_admin.token }} -s {{ cc_jenkins_host }} groovy {{ jenkins_home }}/scripts/offline_slave_cleanup.groovy"

--- a/tasks/helm_release_cleanup.yml
+++ b/tasks/helm_release_cleanup.yml
@@ -8,7 +8,7 @@
 
   - name: Configure Helm release cleanup cron
     cron:
-      name: "Clean up Helm releases older than {{ helm_release_cap }} day(s)"
+      name: "Clean up Helm releases older than {{ helm_release_cap }} hour(s)"
       minute: "30"
       hour: "*"
       job: "python {{ jenkins_home }}/scripts/helm_release_cleanup.py"

--- a/tasks/helm_release_cleanup.yml
+++ b/tasks/helm_release_cleanup.yml
@@ -10,6 +10,6 @@
     cron:
       name: "Clean up Helm releases older than {{ helm_release_cap }} day(s)"
       minute: "30"
-      hour: "12"
+      hour: "*"
       job: "python {{ jenkins_home }}/scripts/helm_release_cleanup.py"
       user: jenkins

--- a/templates/helm_release_cleanup.py.j2
+++ b/templates/helm_release_cleanup.py.j2
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-""" This script cleans up Helm deployments older than X days.
+""" This script cleans up Helm deployments older than X hours.
 
 To run this script, you must have:
 * Helm installed and initialised (helm init)
@@ -13,7 +13,7 @@ import subprocess
 import datetime
 from dateutil.parser import parse
 
-DAYS_TO_KEEP={{ helm_release_cap }}
+HOURS_TO_KEEP={{ helm_release_cap }}
 LOG_FILE="{{ helm_release_log_file }}"
 
 def main():
@@ -26,7 +26,7 @@ def main():
     release_count = len(releases)
 
     if release_count > 0:
-        logging.debug('Found %s releases older than %s day(s)' %(release_count, DAYS_TO_KEEP))
+        logging.debug('Found %s releases older than %s hours(s)' %(release_count, HOURS_TO_KEEP))
 
     releases_deleted = 0
 
@@ -41,7 +41,7 @@ def main():
 
             date = parse(release_updated)
 
-            if date < datetime.datetime.now() - datetime.timedelta(days=DAYS_TO_KEEP):
+            if date < datetime.datetime.now() - datetime.timedelta(hours=HOURS_TO_KEEP):
                 logging.debug('Deleting %s...' %release_name)
                 cmd = "helm delete --purge %s" %release_name
                 output = subprocess.check_call(cmd, shell=True)


### PR DESCRIPTION
* Change release cleanup from 24 to 6 hours
* Run Helm cleanup script hourly
* Add full path for Jenkins.cli JAR