### PR TITLE
Fix cleanup script

### DIFF
--- a/tasks/crons.yml
+++ b/tasks/crons.yml
@@ -18,4 +18,4 @@
       name: "Clean up dead Jenkins slaves"
       minute: "0"
       hour: "*"
-      job: "java -jar {{ jenkins_home }}/jenkins-cli.jar -auth {{ cc_jenkins_admin.user }}:{{ cc_jenkins_admin.token }} -s {{ cc_jenkins_host }} groovy {{ jenkins_home }}/scripts/offline_slave_cleanup.groovy"
+      job: "curl --user '{{ cc_jenkins_admin.user }}:{{ cc_jenkins_admin.token }}' --data-urlencode \"script=$(<{{ jenkins_home }}/scripts/offline_slave_cleanup.groovy)\" {{ cc_jenkins_host }}/scriptText"


### PR DESCRIPTION
# Overview
This PR updates the code with working method of deleting slaves. 

# Details
Running cleaning up script via `jenkins-cli.jar` is depreciated:

```bash
$ java -jar /var/lib/jenkins/jenkins-cli.jar -auth abc:xyz -s http://localhost:8080 groovy /var/lib/jenkins/scripts/offline_slave_cleanup.groovy 

ERROR: This command is requesting the deprecated -remoting mode. See https://jenkins.io/redirect/cli-command-requires-channel
```

It appears that it is no longer supported as it's slow and poses security risks. 

Instead, Jenkins documentary [suggests](https://wiki.jenkins.io/display/JENKINS/Jenkins+Script+Console) using `curl`:

```bash
$ curl --user 'abc:xyz' --data-urlencode "script=$(</var/lib/jenkins/scripts/offline_slave_cleanup.groovy)" http://localhost:8080/scriptText
Cleaning up offline slaves...
Deleting i-0a5a7346a1391ea65
Deleting i-0d81a6d9a93d800d1
Deleting i-0e72e6f01b3b63df7
Done.
```