### PR TITLE
Bump version and fix loop

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,11 +9,11 @@ cc_jenkins_github_administrators: []
 
 cc_jenkins_credentials: {}
 
-cc_jenkins_kubectl_version: 1.7.5
+cc_jenkins_kubectl_version: 1.7.8
 
 cc_jenkins_kops_version: 1.7.0
 
-cc_jenkins_helm_version: 2.6.1
+cc_jenkins_helm_version: 2.7.2
 cc_jenkins_helm_uncompressed_dir: linux-amd64
 
 cc_jenkins_aws_config: {}
@@ -36,5 +36,5 @@ cc_jenkins_plugins: []
 #GeerlingGuy roles' variables
 java_packages: java-1.8.0-openjdk
 
-helm_release_cap: 6 # hours
+helm_release_cap: 24
 helm_release_log_file: helm_release_cleanup.log

--- a/templates/helm_release_cleanup.py.j2
+++ b/templates/helm_release_cleanup.py.j2
@@ -36,7 +36,7 @@ def main():
             release_updated = release.split(",")[1]
 
             # Ignore releases on Master branches
-            if release_name == "web-master" or release_name == "web-api":
+            if release_name == "web-master" or release_name == "api-master":
                 continue
 
             date = parse(release_updated)

--- a/templates/helm_release_cleanup.py.j2
+++ b/templates/helm_release_cleanup.py.j2
@@ -36,8 +36,8 @@ def main():
             release_updated = release.split(",")[1]
 
             # Ignore releases on Master branches
-            if release_name.startswith("web-master") or release_name.startswith("api-master"):
-                pass
+            if release_name == "web-master" or release_name == "web-api":
+                continue
 
             date = parse(release_updated)
 

--- a/test/integration/jenkins/serverspec/localhost/kube_spec.rb
+++ b/test/integration/jenkins/serverspec/localhost/kube_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 describe command('kubectl version') do
-    its(:stdout) { should match /GitVersion\:\"v1\.7\.5\"/ }
+    its(:stdout) { should match /GitVersion\:\"v1\.7\.8\"/ }
 end
 
 describe command('kops version') do
@@ -9,5 +9,5 @@ describe command('kops version') do
 end
 
 describe command('helm version') do
-    its(:stdout) { should match /SemVer\:\"v2\.6\.1\"/ }
+    its(:stdout) { should match /SemVer\:\"v2\.7\.2\"/ }
 end


### PR DESCRIPTION
This PR:
- Bumps `kubectl` and `helm` versions
- Fixes issue where `web-master` & `api-master` releases would be deleted
- Sets 24h for release TTL

```
-----> Destroying <jenkins-centos>...
       ==> default: Forcing shutdown of VM...
       ==> default: Destroying VM and associated drives...
       Vagrant instance <jenkins-centos> destroyed.
       Finished destroying <jenkins-centos> (0m5.18s).
       Finished testing <jenkins-centos> (10m36.11s).
-----> Kitchen is finished. (10m36.51s)
```